### PR TITLE
Fix sphinx delta index

### DIFF
--- a/misc/sphinx.conf
+++ b/misc/sphinx.conf
@@ -249,14 +249,6 @@ source ##OPENSHIFT_APP_NAME##
 	sql_query_info		= SELECT * FROM ttrss_entries,  \
 		ttrss_user_entries WHERE ref_id = id AND int_id=$id
 
-	# kill-list query, fetches the document IDs for kill-list
-	# k-list will suppress matches from preceding indexes in the same query
-	# optional, default is empty
-	#
-	sql_query_killlist	= SELECT int_id FROM ttrss_user_entries \
-		WHERE date_updated>=@last_reindex
-
-
 	# columns to unpack on indexer side when indexing
 	# multi-value, optional, default is empty list
 	#
@@ -315,6 +307,14 @@ source delta : ##OPENSHIFT_APP_NAME## {
 			FROM ttrss_entries, ttrss_user_entries, ttrss_feeds \
 			WHERE ref_id = ttrss_entries.id AND feed_id = ttrss_feeds.id \
 			AND ttrss_entries.updated > NOW() - INTERVAL '24 hours'
+
+	# kill-list query, fetches the document IDs for kill-list
+	# k-list will suppress matches from preceding indexes in the same query
+	# optional, default is empty
+	#
+        sql_query_killlist	= \
+		SELECT int_id FROM ttrss_entries, ttrss_user_entries \
+			WHERE ref_id = ttrss_entries.id AND updated > NOW() - INTERVAL '24 hours'
 
 }
 


### PR DESCRIPTION
While looking through the postgresql logs I noticed the following recurring error.

ERROR:  column "date_updated" does not exist at character 47
STATEMENT:  SELECT int_id FROM ttrss_user_entries               WHERE date_updated>=@last_reindex

I tracked this down to a faulty sphinx configuration. This patch gets rid of the error message and also puts the killlist query in the correct index.
