### PR TITLE
Move cache directories to the data folder

### DIFF
--- a/.openshift/action_hooks/build
+++ b/.openshift/action_hooks/build
@@ -14,6 +14,18 @@ else
     echo "***WARNING***: Be sure to update \$OPENSHIFT_REPO_DIR/php/config.php with content" | tee -a ${OPENSHIFT_PHP_LOG_DIR}/deploy.log
     echo "***WARNING***: from \$OPENSHIFT_REPO_DIR/misc/config.php" | tee -a ${OPENSHIFT_PHP_LOG_DIR}/deploy.log
 fi
+
+# Set up various cache directories
+if [ ! -d ${OPENSHIFT_DATA_DIR}/ttrss ]; then
+  echo "Configuring tt-rss cache directories"| tee -a ${OPENSHIFT_PHP_LOG_DIR}/deploy.log
+  mkdir -p ${OPENSHIFT_DATA_DIR}/ttrss
+  cp -r ${OPENSHIFT_REPO_DIR}/php/{cache,lock} ${OPENSHIFT_DATA_DIR}/ttrss/
+  mv ${OPENSHIFT_REPO_DIR}/php/feed-icons ${OPENSHIFT_DATA_DIR}/ttrss/
+else
+  rm -rf ${OPENSHIFT_REPO_DIR}/php/feed-icons
+fi
+ln -sf ${OPENSHIFT_DATA_DIR}/ttrss/feed-icons ${OPENSHIFT_REPO_DIR}/php/feed-icons
+
 # Set up sphinx full-text search
 if [ ! -d ${OPENSHIFT_DATA_DIR}/run ]; then
   echo "Configuring Sphinx: Directories" | tee -a ${OPENSHIFT_PHP_LOG_DIR}/deploy.log

--- a/misc/config.php
+++ b/misc/config.php
@@ -56,11 +56,11 @@
 	// then most probably you are using the CGI binary. If you are unsure what to 
 	// put in here, ask your hosting provider.
 
-	define('LOCK_DIRECTORY', 'lock');
+	define('LOCK_DIRECTORY', getenv(OPENSHIFT_DATA_DIR) . '/ttrss/lock');
 	// Directory for lockfiles, must be writable to the user you run
 	// daemon process or cronjobs under.
 
-	define('CACHE_DIR', 'cache');
+	define('CACHE_DIR', getenv(OPENSHIFT_DATA_DIR) . '/ttrss/cache'); 
 	// Local cache directory for RSS feed content.
 
 	define('ICONS_DIR', "feed-icons");


### PR DESCRIPTION
Hi,

While working on the last patches I did a lot of test pushes to openshift. During that I noticed that due to the repo being overwritten all caches and especially the feed-icons folder got nuked every time.
What I did for my local branch was to move these directories to the data directory with the exception of the feed-icons dir. Since it is actually used to serve files instead of moving it I moved it to the data dir and created a symbolic link.

This patch is actually working quite well, but maybe there is a better way to implement it.
