### PR TITLE
DETECT_ARTICLE_LANGUAGE in config.php

### DIFF
--- a/misc/config.php
+++ b/misc/config.php
@@ -183,6 +183,12 @@
 
 	define('CHECK_FOR_NEW_VERSION', true);
 	// Check for new versions of tt-rss automatically.
+	
+	define('DETECT_ARTICLE_LANGUAGE', false);
+	// Detect article language when updating feeds, presently this is only
+    	// used for hyphenation. This may increase amount of CPU time used by
+    	// update processes, disable if necessary (i.e. you are being billed
+    	// for CPU time).
 
 	define('ENABLE_GZIP_OUTPUT', true);
 	// Selectively gzip output to improve wire performance. This requires


### PR DESCRIPTION
I updated to version 1.11 and i get:

Required configuration file parameter DETECT_ARTICLE_LANGUAGE is not defined in config.php. You might need to copy it from config.php-dist.

This block should be added in /misc/config.php
